### PR TITLE
removed /images from truffle.js

### DIFF
--- a/SydEth/public/truffleDemo/truffle.js
+++ b/SydEth/public/truffleDemo/truffle.js
@@ -7,7 +7,7 @@ module.exports = {
 		"app.css": [
 			"stylesheets/app.css"
 		],
-		"images/": "images/"
+	//	"images/": "images/"
 	},
 	deploy: [
 		// "MetaCoin",


### PR DESCRIPTION
`$ truffle serve ` was giving error because we dont have `/images` folder in `./app`. 
